### PR TITLE
Maintenance/support php 81

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
         laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
+        exclude:
+          - php: 8.1
+            laravel: 8.*
+            dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,18 @@ jobs:
         php: [7.3, 7.4, 8.0, 8.1]
         laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 8.*
-            testbench: 6.*
         exclude:
           - php: 8.1
             laravel: 8.*
             dependency-version: prefer-lowest
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          #Testing php 8.1 with Laravel 8.74 as its lowest
+          - php: 8.1
+            laravel: ^8.74
+            dependency-version: prefer-lowest
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0",
-        "illuminate/translation": "^6.0|^7.0|^8.0"
+        "illuminate/console": "^8.0",
+        "illuminate/contracts": "^8.0",
+        "illuminate/http": "^8.0",
+        "illuminate/support": "^8.0",
+        "illuminate/routing": "^8.0",
+        "illuminate/translation": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3.3",
         "squizlabs/php_codesniffer": "^3.6"
     },

--- a/tests/Integration/Console/DetectCommandTest.php
+++ b/tests/Integration/Console/DetectCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Integration\Console;
+
+use Exolnet\Translation\Editor\Console\DetectCommand;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+use Exolnet\Translation\Editor\TranslationEditor;
+use Illuminate\Contracts\Container\Container;
+use Mockery as m;
+use Symfony\Component\Console\Input\Input;
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Finder\Finder;
+
+class DetectCommandTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\TranslationEditor|\Mockery\MockInterface
+     */
+    protected $translationEditor;
+
+    /**
+     * @var \Exolnet\Translation\Editor\Console\DetectCommand
+     */
+    protected $detectCommand;
+
+    /**
+     * @var \Symfony\Component\Console\Input\Input\|\Mockery\MockInterface
+     */
+    protected $input;
+
+    /**
+     * @var \Illuminate\Console\OutputStyle|\Mockery\MockInterface
+     */
+    protected $output;
+
+    /**
+     * @var \Illuminate\Contracts\Container\Container|\Mockery\MockInterface
+     */
+    protected $laravel;
+
+    /**
+     * @var \Symfony\Component\Finder\Finder
+     */
+    protected $finder;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translationEditor = m::mock(TranslationEditor::class);
+        $this->input = m::mock(Input::class);
+        $this->output = m::mock(OutputStyle::class);
+        $this->laravel = m::mock(Container::class);
+
+        $this->finder = new finder();
+        $this->detectCommand = new DetectCommand($this->translationEditor);
+        $this->detectCommand->setInput($this->input);
+        $this->detectCommand->setOutput($this->output);
+        $this->detectCommand->setLaravel($this->laravel);
+    }
+
+    public function testHandle()
+    {
+        $this->input->shouldReceive('getArgument')->once()->andReturn('tests/TestFiles');
+        $this->output->shouldReceive('writeln')->times(7);
+        $this->output->shouldReceive('confirm')->once()->andReturn(true);
+        $this->translationEditor->shouldReceive('findVariablesForText')->twice()->andReturn([]);
+        $this->input->shouldReceive('getOption')->times(6);
+        $this->laravel->shouldReceive('getLocale')->times(6)->andReturn('fr');
+        $this->output->shouldReceive('askQuestion')->twice()->andReturn('replaced text');
+        $this->translationEditor->shouldReceive('getAllDefinedNames')->twice()->andReturn([]);
+        $this->translationEditor->shouldReceive('storeTranslation')->twice();
+
+        $this->assertStringContainsString(
+            'DetectCommand title="testing first regex"',
+            file_get_contents(getcwd() . '/tests/TestFiles/detectCommandRegex.php')
+        );
+        $this->assertStringContainsString(
+            '> testing second regex </',
+            file_get_contents(getcwd() . '/tests/TestFiles/detectCommandRegex.php')
+        );
+
+        $this->detectCommand->handle($this->finder);
+
+        $this->assertStringContainsString(
+            'DetectCommand title="@te(\'replaced text\')"',
+            file_get_contents(getcwd() . '/tests/TestFiles/detectCommandRegex.php')
+        );
+        $this->assertStringContainsString(
+            '> @te(\'replaced text\') </',
+            file_get_contents(getcwd() . '/tests/TestFiles/detectCommandRegex.php')
+        );
+
+        //Reset the content of the file
+        file_put_contents(
+            getcwd() . '/tests/TestFiles/detectCommandRegex.php',
+            '<?php
+\'DetectCommand title="testing first regex"\';
+\'> testing second regex </\';
+'
+        );
+    }
+}

--- a/tests/Integration/Console/TranslateCommandTest.php
+++ b/tests/Integration/Console/TranslateCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Integration\Console;
+
+use Exolnet\Translation\Editor\Console\TranslateCommand;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+use Exolnet\Translation\Editor\TranslationEditor;
+use Mockery as m;
+use Symfony\Component\Console\Input\Input;
+use Illuminate\Console\OutputStyle;
+
+class TranslateCommandTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\TranslationEditor|\Mockery\MockInterface
+     */
+    protected $translationEditor;
+
+    /**
+     * @var \Exolnet\Translation\Editor\Console\TranslateCommand
+     */
+    protected $translateCommand;
+
+    /**
+     * @var \Symfony\Component\Console\Input\Input\|\Mockery\MockInterface
+     */
+    protected $input;
+
+    /**
+     * @var \Illuminate\Console\OutputStyle|\Mockery\MockInterface
+     */
+    protected $output;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translationEditor = m::mock(TranslationEditor::class);
+        $this->input = m::mock(Input::class);
+        $this->output = m::mock(OutputStyle::class);
+
+        $this->translateCommand = new TranslateCommand($this->translationEditor);
+        $this->translateCommand->setInput($this->input);
+        $this->translateCommand->setOutput($this->output);
+    }
+
+    public function testHandle()
+    {
+        $this->input->shouldReceive('getOption')->once()->andReturn('tests/TestFiles');
+        $this->input->shouldReceive('getArgument')->once()->andReturn(['fr', 'es']);
+        $this->output->shouldReceive('writeln')->twice();
+        $this->translationEditor->shouldReceive('loadAllGroups')->twice();
+        $this->translationEditor->shouldReceive('getAllDefinedNames')->twice()->andReturn([]);
+        $this->output->shouldReceive('ask')->times(8)->andReturn('replaced text');
+        //4 different variables read from tests/Testfiles/translateCommadRegex called 2 times each
+        //cause 2 locales returned by mocked getArgument (4 * 2 = 8 times storeTranslation is called)
+        $this->translationEditor->shouldReceive('storeTranslation')->times(8);
+
+        $this->translateCommand->handle();
+    }
+}

--- a/tests/Integration/Controllers/AssetControllerTest.php
+++ b/tests/Integration/Controllers/AssetControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Integration\Controllers;
+
+use Exolnet\Translation\Editor\Controllers\AssetController;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+
+class AssetControllerTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\Controllers\AssetController
+     */
+    protected $assetController;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->assetController = new AssetController();
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testJs(): void
+    {
+        $response = $this->assetController->js();
+
+        $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
+        $this->assertCacheResponse($response);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testCss(): void
+    {
+        $response = $this->assetController->css();
+
+        $this->assertEquals('text/css', $response->headers->get('Content-Type'));
+        $this->assertCacheResponse($response);
+    }
+
+    /**
+     * @param $response
+     * @return void
+     */
+    public function assertCacheResponse($response): void
+    {
+        $this->assertTrue($response->isCacheable());
+        $this->assertEquals(31536000, $response->headers->getCacheControlDirective('max-age'));
+        $this->assertEquals(31536000, $response->headers->getCacheControlDirective('s-maxage'));
+        $dateTime = new \DateTime('+1 year');
+        $this->assertEquals($response->getExpires()->format('y/m/d'), $dateTime->format('y/m/d'));
+    }
+}

--- a/tests/Integration/Controllers/TranslationControllerTest.php
+++ b/tests/Integration/Controllers/TranslationControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Integration\Controllers;
+
+use Exolnet\Translation\Editor\Controllers\TranslationController;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+use Exolnet\Translation\Editor\TranslationEditor;
+use Illuminate\Http\Request;
+use Mockery as m;
+
+class TranslationControllerTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\TranslationEditor|\Mockery\MockInterface
+     */
+    protected $translationEditor;
+
+    /**
+     * @var \Exolnet\Translation\Editor\Controllers\TranslationController
+     */
+    protected $translationController;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->translationEditor = m::mock(TranslationEditor::class);
+        $this->translationController = new TranslationController($this->translationEditor);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testShow(): void
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('get')->with('locale')->once()->andReturn('fr');
+        $request->shouldReceive('get')->with('path')->once()->andReturn('/');
+        $returnedArray = [
+            'path' => '/',
+            'source' => [
+                'locale' => 'fr',
+                'translation' => 'fr',
+            ],
+            'destination' => [
+                'locale' => 'fr',
+                'translation' => 'fr',
+            ],
+        ];
+        $this->translationEditor
+            ->shouldReceive('retrieveTranslation')
+            ->withArgs(['/', 'fr'])
+            ->once()
+            ->andReturn($returnedArray);
+
+        $response = $this->translationController->show($request);
+        $this->assertEquals(json_encode($returnedArray), $response->getContent());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testStore(): void
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('get')->with('locale')->once()->andReturn('fr');
+        $request->shouldReceive('get')->with('path')->once()->andReturn('/');
+        $request->shouldReceive('get')->with('translation')->once()->andReturn('test');
+
+        $this->translationEditor
+            ->shouldReceive('storeTranslation')
+            ->withArgs(['/', 'test', 'fr'])
+            ->once();
+
+        $response = $this->translationController->store($request);
+        $this->assertEquals(json_encode(['compiled' => 'test']), $response->getContent());
+    }
+}

--- a/tests/Integration/Middleware/TranslationEditorEnabledTest.php
+++ b/tests/Integration/Middleware/TranslationEditorEnabledTest.php
@@ -38,7 +38,6 @@ class TranslationEditorEnabledTest extends TestCase
 
         $this->translationEditor->shouldReceive('isEnabled')->once()->andReturn(true);
         $this->translationEditorEnabled->handle($request, function ($req) {
-            $this->assertTrue(true);
         });
     }
 

--- a/tests/Integration/Middleware/TranslationEditorEnabledTest.php
+++ b/tests/Integration/Middleware/TranslationEditorEnabledTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Unit\Middleware;
+
+use Exolnet\Translation\Editor\Middleware\TranslationEditorEnabled;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+use Exolnet\Translation\Editor\TranslationEditor;
+use Illuminate\Http\Request;
+use Mockery as m;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class TranslationEditorEnabledTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\Middleware\TranslationEditorEnabled
+     */
+    protected $translationEditorEnabled;
+
+    /**
+     * @var \Exolnet\Translation\Editor\TranslationEditor|\Mockery\LegacyMockInterface|\Mockery\MockInterface
+     */
+    protected $translationEditor;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->translationEditor = m::mock(TranslationEditor::class);
+        $this->translationEditorEnabled = new TranslationEditorEnabled($this->translationEditor);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testHandle(): void
+    {
+        $request = new Request();
+
+        $this->translationEditor->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->translationEditorEnabled->handle($request, function ($req) {
+            $this->assertTrue(true);
+        });
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testHandleAbort(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $request = new Request();
+
+        $this->translationEditor->shouldReceive('isEnabled')->once()->andReturn(false);
+        $this->translationEditorEnabled->handle($request, function ($req) {
+        });
+    }
+}

--- a/tests/Integration/Middleware/TranslationEditorInjectTest.php
+++ b/tests/Integration/Middleware/TranslationEditorInjectTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Unit\Middleware;
+
+use Exolnet\Translation\Editor\Middleware\TranslationEditorInject;
+use Exolnet\Translation\Editor\Tests\Integration\TestCase;
+use Exolnet\Translation\Editor\TranslationEditor;
+use Illuminate\Http\Request;
+use Mockery as m;
+use Symfony\Component\HttpFoundation\Response;
+
+class TranslationEditorInjectTest extends TestCase
+{
+    /**
+     * @var \Exolnet\Translation\Editor\Middleware\TranslationEditorInject
+     */
+    protected $translationEditorInject;
+
+    /**
+     * @var \Exolnet\Translation\Editor\TranslationEditor|\Mockery\LegacyMockInterface|\Mockery\MockInterface
+     */
+    protected $translationEditor;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->translationEditor = m::mock(TranslationEditor::class);
+        $this->translationEditorInject = new TranslationEditorInject($this->translationEditor);
+    }
+
+    /**
+     * @test
+     * @return void
+     * @throws \Exception
+     */
+    public function testHandleInjected(): void
+    {
+        $request = new Request();
+
+        $this->translationEditor->shouldReceive('isEnabled')->once()->andReturn(true);
+
+        $response = $this->translationEditorInject->handle($request, function ($req) {
+            return new Response('</translation-editor></head>', 200, [
+                'Content-Type' =>'html'
+            ]);
+        });
+        $this->assertStringContainsString('<script', $response->getContent());
+        $this->assertStringContainsString('<link', $response->getContent());
+    }
+
+    /**
+     * @test
+     * @return void
+     * @throws \Exception
+     */
+    public function testHandleShouldNotInject(): void
+    {
+        $request = new Request();
+
+        $this->translationEditor->shouldReceive('isEnabled')->once()->andReturn(false);
+
+        $response = $this->translationEditorInject->handle($request, function ($req) {
+            return new Response('', 200, []);
+        });
+        $this->assertStringNotContainsString('<script', $response->getContent());
+        $this->assertStringNotContainsString('<link', $response->getContent());
+    }
+}

--- a/tests/Integration/TranslationEditorTest.php
+++ b/tests/Integration/TranslationEditorTest.php
@@ -64,7 +64,6 @@ class TranslationEditorTest extends TestCase
         $this->assertEquals(['en', 'fr', 'es'], $this->editor->getLocales());
     }
 
-
     /**
      * @test
      * @return void

--- a/tests/Integration/TranslationEditorTest.php
+++ b/tests/Integration/TranslationEditorTest.php
@@ -2,12 +2,79 @@
 
 namespace Exolnet\Translation\Editor\Tests\Integration;
 
+use Exolnet\Translation\Editor\TranslationEditor;
+use Exolnet\Translation\Editor\Translator;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+
 class TranslationEditorTest extends TestCase
 {
+    /**
+     * @var \Mockery\MockInterface|\Exolnet\Translation\Editor\TranslationEditor
+     */
+    protected $editor;
+
+    /**
+     * @var \Mockery\MockInterface|\Illuminate\Contracts\Config\Repository
+     */
+    protected $config;
+
+    /**
+     * @var \Mockery\MockInterface|\Exolnet\Translation\Editor\Translator
+     */
+    protected $translator;
+
+    /**
+     * @var \Mockery\MockInterface|\Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->config = m::mock(Config::class);
+        $this->translator = m::mock(Translator::class);
+        $this->filesystem = m::mock(Filesystem::class);
+
+        $this->editor = new TranslationEditor($this->config, $this->translator, $this->filesystem);
+    }
+
     public function testItIsDisabledByDefault()
     {
         $enabled = $this->app['translation.editor']->isEnabled();
 
         $this->assertFalse($enabled);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testGetLocales()
+    {
+        $this->translator->shouldReceive('getFallback')
+            ->once()
+            ->andReturn('en');
+
+        $this->filesystem->shouldReceive('directories')
+            ->once()
+            ->andReturn(['fr', 'es']);
+
+        $this->assertEquals(['en', 'fr', 'es'], $this->editor->getLocales());
+    }
+
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testStoreTranslation(): void
+    {
+        $this->translator->shouldReceive('has')->once()->andReturn(true);
+        $this->translator->shouldReceive('get')->once()->andReturn(['fr', 'en', 'es']);
+
+        $this->filesystem->shouldReceive('put')->once()->andReturn(true);
+        $this->editor->storeTranslation('tests.test', 'bonjour', 'fr');
     }
 }

--- a/tests/TestFiles/detectCommandRegex.php
+++ b/tests/TestFiles/detectCommandRegex.php
@@ -1,0 +1,3 @@
+<?php
+'DetectCommand title="testing first regex"';
+'> testing second regex </';

--- a/tests/TestFiles/translateCommandRegex.php
+++ b/tests/TestFiles/translateCommandRegex.php
@@ -1,0 +1,5 @@
+<?php
+@te('label.regex1');
+__('label.regex2');
+@lang('label.regex3');
+te('label.regex4');

--- a/tests/Unit/TranslationEditorTest.php
+++ b/tests/Unit/TranslationEditorTest.php
@@ -36,7 +36,11 @@ class TranslationEditorTest extends UnitTest
         $this->translator = m::mock(Translator::class);
         $this->filesystem = m::mock(Filesystem::class);
 
-        $this->editor = new TranslationEditor($this->config, $this->translator, $this->filesystem);
+        $this->editor= m::mock(TranslationEditor::class, [
+            $this->config,
+            $this->translator,
+            $this->filesystem
+        ])->makePartial();
     }
 
     public function testIsEditorDisabledByDefault()
@@ -113,5 +117,73 @@ class TranslationEditorTest extends UnitTest
             ->andReturn(['fr', 'en']);
 
         $this->assertEquals(['fr', 'en'], $this->editor->detectLocales());
+    }
+
+    public function testRetrieveTranslation()
+    {
+        $this->editor->shouldReceive('getLocales')->once()->andReturn(['fr', 'es']);
+
+        $this->translator->shouldReceive('has')->twice()->andReturn(true);
+        $this->translator->shouldReceive('get')->twice()->andReturn('fr');
+
+        $fakePath = 'test';
+        $fakeLocale = 'fr';
+
+        $expectedArray = [
+            'path' => $fakePath,
+            'source' => [
+                'locale' => 'es',
+                'translation' => 'fr',
+            ],
+            'destination' => [
+                'locale' => $fakeLocale,
+                'translation' => 'fr',
+            ],
+        ];
+        $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath, $fakeLocale));
+    }
+
+    public function testRetrieveTranslationNoLocale()
+    {
+        $this->editor->shouldReceive('getLocales')->once()->andReturn(['fr', 'es']);
+
+        $this->translator->shouldReceive('has')->twice()->andReturn(true);
+        $this->translator->shouldReceive('get')->twice()->andReturn('fr');
+
+        $fakePath = 'test';
+
+        $expectedArray = [
+            'path' => $fakePath,
+            'source' => [
+                'locale' => 'fr',
+                'translation' => 'fr',
+            ],
+            'destination' => [
+                'locale' => null,
+                'translation' => 'fr',
+            ],
+        ];
+        $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath));
+    }
+
+    public function testRetrieveTranslationGetLocalesNull()
+    {
+        $this->editor->shouldReceive('getLocales')->once()->andReturn([]);
+        $this->translator->shouldReceive('has')->once()->andReturn(false);
+
+        $fakePath = 'test';
+
+        $expectedArray = [
+            'path' => $fakePath,
+            'source' => [
+                'locale' => null,
+                'translation' => null,
+            ],
+            'destination' => [
+                'locale' => null,
+                'translation' => null,
+            ],
+        ];
+        $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath));
     }
 }

--- a/tests/Unit/TranslationEditorTest.php
+++ b/tests/Unit/TranslationEditorTest.php
@@ -32,6 +32,7 @@ class TranslationEditorTest extends UnitTest
 
     public function setUp(): void
     {
+        parent::setUp();
         $this->config = m::mock(Config::class);
         $this->translator = m::mock(Translator::class);
         $this->filesystem = m::mock(Filesystem::class);
@@ -119,6 +120,12 @@ class TranslationEditorTest extends UnitTest
         $this->assertEquals(['fr', 'en'], $this->editor->detectLocales());
     }
 
+
+
+    /**
+     * @test
+     * @return void
+     */
     public function testRetrieveTranslation()
     {
         $this->editor->shouldReceive('getLocales')->once()->andReturn(['fr', 'es']);
@@ -143,6 +150,10 @@ class TranslationEditorTest extends UnitTest
         $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath, $fakeLocale));
     }
 
+    /**
+     * @test
+     * @return void
+     */
     public function testRetrieveTranslationNoLocale()
     {
         $this->editor->shouldReceive('getLocales')->once()->andReturn(['fr', 'es']);
@@ -166,6 +177,10 @@ class TranslationEditorTest extends UnitTest
         $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath));
     }
 
+    /**
+     * @test
+     * @return void
+     */
     public function testRetrieveTranslationGetLocalesNull()
     {
         $this->editor->shouldReceive('getLocales')->once()->andReturn([]);
@@ -186,4 +201,5 @@ class TranslationEditorTest extends UnitTest
         ];
         $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath));
     }
+
 }

--- a/tests/Unit/TranslationEditorTest.php
+++ b/tests/Unit/TranslationEditorTest.php
@@ -120,8 +120,6 @@ class TranslationEditorTest extends UnitTest
         $this->assertEquals(['fr', 'en'], $this->editor->detectLocales());
     }
 
-
-
     /**
      * @test
      * @return void
@@ -201,5 +199,4 @@ class TranslationEditorTest extends UnitTest
         ];
         $this->assertEquals($expectedArray, $this->editor->retrieveTranslation($fakePath));
     }
-
 }

--- a/tests/Unit/TranslationEditorTest.php
+++ b/tests/Unit/TranslationEditorTest.php
@@ -88,4 +88,30 @@ class TranslationEditorTest extends UnitTest
         $this->assertTrue(strpos($result, 'path="default.title"') !== false);
         $this->assertTrue(strpos($result, 'Title') !== false);
     }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testDetectLocales(): void
+    {
+        $this->config->shouldReceive('get')
+            ->with('app.supported_locales')
+            ->once()
+            ->andReturnNull();
+
+        $this->config->shouldReceive('get')
+            ->with('app.locale')
+            ->once()
+            ->andReturn('en');
+
+        $this->assertEquals(['en'], $this->editor->detectLocales());
+
+        $this->config->shouldReceive('get')
+            ->with('app.supported_locales')
+            ->once()
+            ->andReturn(['fr', 'en']);
+
+        $this->assertEquals(['fr', 'en'], $this->editor->detectLocales());
+    }
 }

--- a/tests/Unit/TranslatorTest.php
+++ b/tests/Unit/TranslatorTest.php
@@ -85,7 +85,8 @@ class TranslatorTest extends TestCase
         try {
             $this->translator->getAllVariables($locale, $namespace);
         } catch (Exception $exception) {
-            $this->assertEquals("Undefined index: " . $namespace, $exception->getMessage());
+            $this->assertStringContainsString($namespace, $exception->getMessage());
+            $this->assertStringContainsString('Undefined', $exception->getMessage());
         }
     }
 }

--- a/tests/Unit/TranslatorTest.php
+++ b/tests/Unit/TranslatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Exolnet\Translation\Editor\Tests\Unit;
+
+use Exception;
+use Exolnet\Translation\Editor\Translator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class TranslatorTest extends TestCase
+{
+    /** @var \Mockery\Mock|\Exolnet\Translation\Editor\Translator*/
+    private $translator;
+
+    public function setUp(): void
+    {
+        $this->translator = m::mock(Translator::class)->makePartial();
+        $this->translator->setLoaded([
+            'label' => [
+                'hour' => [
+                    'fr' => 'heure',
+                    'en' => 'hour',
+                ],
+                'results' => [
+                    'fr' => 'résultats',
+                    'en' => 'results',
+                ],
+            ],
+            'errors' => [
+                'no_error' => [
+                    'fr' => 'aucune erreur',
+                    'en' => 'no error'
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testGetALlVariables(): void
+    {
+        $actualArray = $this->translator->getAllVariables('fr', 'label');
+        $expectedArray = [
+            'hour' => 'heure',
+            'results' => 'résultats'
+        ];
+        $this->assertEquals($expectedArray, $actualArray);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testGetAllDefinedNames(): void
+    {
+        $actualArray = $this->translator->getAllDefinedNames('fr', 'label');
+        $expectedArray = [
+            'hour',
+            'results'
+        ];
+        $this->assertEquals($expectedArray, $actualArray);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testUnloadAll(): void
+    {
+        $this->translator->unloadAll();
+
+        $this->tryCatchUndefinedIndex('fr', 'label');
+        $this->tryCatchUndefinedIndex('en', 'label');
+        $this->tryCatchUndefinedIndex('fr', 'error');
+    }
+
+    /**
+     * @param string $locale
+     * @param string $namespace
+     */
+    private function tryCatchUndefinedIndex(string $locale, string $namespace): void
+    {
+        try {
+            $this->translator->getAllVariables($locale, $namespace);
+        } catch (Exception $exception) {
+            $this->assertEquals("Undefined index: " . $namespace, $exception->getMessage());
+        }
+    }
+}

--- a/tests/Unit/TranslatorTest.php
+++ b/tests/Unit/TranslatorTest.php
@@ -5,9 +5,8 @@ namespace Exolnet\Translation\Editor\Tests\Unit;
 use Exception;
 use Exolnet\Translation\Editor\Translator;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
 
-class TranslatorTest extends TestCase
+class TranslatorTest extends UnitTest
 {
     /** @var \Mockery\Mock|\Exolnet\Translation\Editor\Translator*/
     private $translator;


### PR DESCRIPTION
Dropped support for laravel 6 and 7 : [#34493](https://redmine.exolnet.com/issues/34493)
Tested support for php 8.1 : [#34480](https://redmine.exolnet.com/issues/34480)

This branch was also built on feature/improve-test-coverage. So checkout the PR for this other branch before this one