### PR TITLE
feat: add support PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "8.5.*",
+        "php": "^8.2",
         "illuminate/console": "^11.0|^12.0",
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/http": "^11.0|^12.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "8.5.*",
         "illuminate/console": "^11.0|^12.0",
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/http": "^11.0|^12.0",


### PR DESCRIPTION
This pull request updates the project to require PHP 8.5 exclusively, removing support for earlier PHP 8.x versions. The changes also update the test workflow to only run against PHP 8.5. This ensures the codebase and tests are aligned with the latest PHP version.

Dependency and compatibility updates:

* Updated the `composer.json` file to require PHP version `8.5.*` instead of allowing any `^8.2` version.

Continuous integration workflow updates:

* Changed the GitHub Actions test workflow (`.github/workflows/tests.yml`) to only test against PHP 8.5, removing testing for PHP 8.2, 8.3, and 8.4.

Ref: #57416