### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,8 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
       - name: Execute tests
         run: composer test
 

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/console": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/translation": "^11.0|^12.0"
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/routing": "^11.0|^12.0|^13.0",
+        "illuminate/translation": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the project's dependencies and CI workflow to add support for Laravel 13 and PHPUnit 12. The changes ensure that the package remains compatible with the latest versions of Laravel and PHPUnit, and that the test matrix in GitHub Actions covers these new versions appropriately.

Dependency and compatibility updates:

* Updated the `composer.json` file to require Laravel 13 (`illuminate/*` packages) and PHPUnit 12, along with the corresponding version of `orchestra/testbench`, ensuring compatibility with the latest frameworks.

Continuous Integration workflow improvements:

* Expanded the GitHub Actions test matrix in `.github/workflows/tests.yml` to include Laravel 13, PHPUnit 12, and the appropriate `orchestra/testbench` versions. Also, added exclusions to avoid incompatible version combinations and updated the job name to reflect the PHPUnit version.
* Modified the dependencies installation step in the workflow to explicitly require the correct version of PHPUnit for each test matrix entry.
* Enabled manual workflow dispatch for the test workflow, allowing tests to be triggered manually from the GitHub UI.